### PR TITLE
Amendments to raw.speeches

### DIFF
--- a/scripts/load/speeches.py
+++ b/scripts/load/speeches.py
@@ -22,6 +22,9 @@ def processing(date_yyyymmdd, topics_list):
     df["speech_order"] = speech_orders
     df["speech_id"] = df.apply(speeches.speech_cid, axis=1)
 
+    result = df.apply(speeches.count_words_and_characters, axis=1)
+    df = pd.concat([df, result[["num_words", "num_characters"]]], axis=1)
+
     return df
 
 
@@ -33,8 +36,11 @@ def dataframe(date_yyyymmdd, topics_list):
             "speech_id": df["speech_id"],
             "topic_id": df["Topic_CID"],
             "speech_order": df["speech_order"],
+            "member_name_original": df["Original_MP_Name"],
             "member_name": df["MP_Name"],
             "text": df["Text"],
+            "num_words": df["num_words"],
+            "num_characters": df["num_characters"],
         }
     )
 

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -46,6 +46,17 @@ def topic_dataframe(content, topic_cid, index):
     return temp_df
 
 
+def count_words_and_characters(row):
+    text = row["Text"]
+    words = text.split()
+    num_words = len(words)
+    num_characters = len(
+        re.findall(r"[a-zA-Z]", text)
+    )  # count only alphabetic characters
+
+    return pd.Series({"num_words": num_words, "num_characters": num_characters})
+
+
 def process_content(soup):
     # 1. get content out
 

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -41,7 +41,8 @@ def topic_dataframe(content, topic_cid, index):
         }
     )
 
-    temp_df = clean_rows(temp_df)
+    if len(temp_df) > 0:
+        temp_df = clean_rows(temp_df)
 
     return temp_df
 

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -9,6 +9,13 @@ def speech_cid(row):
 
 
 def clean_rows(temp_df):
+    # 1. remove "proc text" from header
+
+    proc_text_pattern = re.compile(r"proc text", flags=re.IGNORECASE)
+    temp_df["Text"] = temp_df["Text"].str.replace(proc_text_pattern, "")
+
+    # 2. drop rows which say "Page" and are blank
+
     page_number_pattern = re.compile(r"Page  \d+")
     temp_df = temp_df[
         ~temp_df["Text"].astype(str).str.contains(page_number_pattern)

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -20,7 +20,7 @@ def clean_rows(temp_df):
 
 def topic_dataframe(content, topic_cid, index):
     soup = BeautifulSoup(content, "html.parser")
-    speakers, texts, sequences = process_content(soup)
+    speakers, texts = process_content(soup)
     print(f"Topic: {topic_cid}, Index (of Topic List): {index}")
 
     cleaned_speakers = [transform.get_mp_name(speaker) for speaker in speakers]
@@ -31,7 +31,6 @@ def topic_dataframe(content, topic_cid, index):
             "Original_MP_Name": speakers,
             "MP_Name": cleaned_speakers,
             "Text": texts,
-            "Seq": sequences,
         }
     )
 
@@ -41,6 +40,8 @@ def topic_dataframe(content, topic_cid, index):
 
 
 def process_content(soup):
+    # 1. get content out
+
     speakers = []
     texts = []
     sequences = []
@@ -64,7 +65,22 @@ def process_content(soup):
                     text.strip().replace("\xa0", " ").replace(":", " ").strip()
                 )
                 sequences.append(sequence)
-        except:
-            print(f"Error at: {index}")
+        except Exception as e:
+            print(f"Error at: {index} - {e}")
 
-    return speakers, texts, sequences
+    # 2. combine texts by speaker
+
+    revised_speakers = []
+    revised_texts = []
+
+    last_speaker = None
+
+    for index in range(len(speakers)):
+        if last_speaker == speakers[index]:
+            revised_texts[-1] += " " + texts[index]
+        else:
+            revised_speakers.append(speakers[index])
+            revised_texts.append(texts[index])
+            last_speaker = speakers[index]
+
+    return revised_speakers, revised_texts

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -73,9 +73,13 @@ def process_content(soup):
                     text = text + " " + p.find("span").get_text()
                 sequence = 1
             else:
-                speaker = speakers[-1] if index > 0 else ""
+                if len(speakers) > 0:
+                    speaker = speakers[-1] if index > 0 else ""
+                    sequence = sequences[-1] + 1 if index > 0 else 1
+                else:
+                    speaker = ""
+                    sequence = 1
                 text = str(p.text)
-                sequence = sequences[-1] + 1 if index > 0 else 1
 
             if text != "None":
                 speakers.append(speaker)


### PR DESCRIPTION
The following is done:

**[1] Merge speeches from different MPs into one row. Previously, each row represented each paragraph in the html file. This is not as useful for analysis and is therefore combined.**

Note that as a result, the `sequence` column will no longer exist in the raw file.

Before:
<img width="780" alt="image" src="https://github.com/jeremychia/singapore-parliament-speeches/assets/38421339/31bea8e6-51ab-4ff8-a034-abbdd5b4d117">

After: 
<img width="1271" alt="image" src="https://github.com/jeremychia/singapore-parliament-speeches/assets/38421339/76dc96d1-aa45-47e8-af72-52d84f193450">

**[2] Remove `proc text` from the speech texts. This is misleading as it may inflate the word count and gets filtered out anyway.**

<img width="579" alt="image" src="https://github.com/jeremychia/singapore-parliament-speeches/assets/38421339/679669e0-db6d-4a8e-93b4-d351e69f2468">

**[3] Include columns `num_words`, `num_characters`.**

For the `speech_text`, this is defined as the following:

`num_words`: Count of number of words within a given speech.
`num_characters`: Count of number of characters (alphabetic characters only) within a given speech. i.e. Cumulative lenght of all words within the speech.
