### PR TITLE
fix: do not combine speeches for questions

### DIFF
--- a/scripts/load/speeches.py
+++ b/scripts/load/speeches.py
@@ -39,6 +39,7 @@ def dataframe(date_yyyymmdd, topics_list):
 
     speeches_df = pd.DataFrame(
         {
+            "date": df["date"],
             "speech_id": df["speech_id"],
             "topic_id": df["Topic_CID"],
             "speech_order": df["speech_order"],

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -164,11 +164,18 @@ def process_content(soup):
     last_speaker = None
 
     for index in range(len(speakers)):
-        if last_speaker == speakers[index] and not texts[index].strip().startswith(
-            "asked"
+        # other conditions are indicative of a question, and therefore should not be added to the next text
+        if (
+            last_speaker == speakers[index]
+            and not texts[index].strip().lower().startswith("asked")
+            and not "to ask" in texts[index].strip().lower()[:10]
         ):
+            print(
+                f"if: {not 'to ask' in texts[index].strip().lower()[:10]} {texts[index]}"
+            )
             revised_texts[-1] += " " + texts[index]
         else:
+            print(f"else: {texts[index]}")
             revised_speakers.append(speakers[index])
             revised_texts.append(texts[index])
             last_speaker = speakers[index]

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -20,9 +20,12 @@ def clean_rows(temp_df):
     temp_df["Text"] = temp_df["Text"].str.replace("proc text", "", case=False)
 
     # 3. Remove "pages" from header
-    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "", regex=True)
+    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "")
 
-    # 4. Drop blank rows
+    # 4. Remove "None" from header
+    temp_df["Text"] = temp_df["Text"].str.replace("None", "")
+
+    # 5. Drop blank rows
     temp_df = temp_df[temp_df["Text"].astype(str) != ""]
 
     return temp_df

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -173,12 +173,8 @@ def process_content(soup):
             and not texts[index].strip().lower().startswith("asked")
             and not "to ask" in texts[index].strip().lower()[:10]
         ):
-            print(
-                f"if: {not 'to ask' in texts[index].strip().lower()[:10]} {texts[index]}"
-            )
             revised_texts[-1] += " " + texts[index]
         else:
-            print(f"else: {texts[index]}")
             revised_speakers.append(speakers[index])
             revised_texts.append(texts[index])
             last_speaker = speakers[index]

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -20,7 +20,7 @@ def clean_rows(temp_df):
     temp_df["Text"] = temp_df["Text"].str.replace("proc text", "", case=False)
 
     # 3. Remove "pages" from header
-    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "")
+    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "", regex=True)
 
     # 4. Remove "None" from header
     temp_df["Text"] = temp_df["Text"].str.replace("None", "")

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -125,7 +125,10 @@ def process_content(soup):
     for index, p in enumerate(soup.find_all("p")):
         try:
             if p.strong:
-                if str(p.strong.text).strip() == "" and index > 0:
+                if (
+                    str(p.strong.text).strip() == ""
+                    or len(str(p.strong.text).strip()) < 3
+                ) and index > 0:
                     speaker = speakers[-1]
                 else:
                     speaker = str(p.strong.text).strip()

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -20,7 +20,7 @@ def clean_rows(temp_df):
     temp_df["Text"] = temp_df["Text"].str.replace("proc text", "", case=False)
 
     # 3. Remove "pages" from header
-    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "")
+    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "", regex=True)
 
     # 4. Drop blank rows
     temp_df = temp_df[temp_df["Text"].astype(str) != ""]
@@ -146,7 +146,11 @@ def process_content(soup):
             if text != "None":
                 speakers.append(speaker)
                 texts.append(
-                    text.strip().replace("\xa0", " ").replace(":", " ").strip()
+                    text.strip()
+                    .replace("\xa0", " ")
+                    .replace("\t", " ")
+                    .replace(":", " ")
+                    .strip()
                 )
                 sequences.append(sequence)
         except Exception as e:

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -146,16 +146,15 @@ def process_content(soup):
                     sequence = 1
                 text = str(p.text)
 
-            if text != "None":
-                speakers.append(speaker)
-                texts.append(
-                    text.strip()
-                    .replace("\xa0", " ")
-                    .replace("\t", " ")
-                    .replace(":", " ")
-                    .strip()
-                )
-                sequences.append(sequence)
+            speakers.append(speaker)
+            texts.append(
+                text.strip()
+                .replace("\xa0", " ")
+                .replace("\t", " ")
+                .replace(":", " ")
+                .strip()
+            )
+            sequences.append(sequence)
         except Exception as e:
             print(f"Error at: {index} - {e}")
 

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -40,6 +40,7 @@ def topic_dataframe(content, topic_cid, index):
 
     temp_df = pd.DataFrame(
         {
+            "date": [topic_cid[:10]] * len(speakers),
             "Topic_CID": [topic_cid] * len(speakers),
             "Original_MP_Name": speakers,
             "MP_Name": cleaned_speakers,

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -159,7 +159,9 @@ def process_content(soup):
     last_speaker = None
 
     for index in range(len(speakers)):
-        if last_speaker == speakers[index]:
+        if last_speaker == speakers[index] and not texts[index].strip().startswith(
+            "asked"
+        ):
             revised_texts[-1] += " " + texts[index]
         else:
             revised_speakers.append(speakers[index])

--- a/scripts/transform/speeches.py
+++ b/scripts/transform/speeches.py
@@ -11,17 +11,18 @@ def speech_cid(row):
 
 
 def clean_rows(temp_df):
-    # 1. remove "proc text" from header
+    # 1. Remove HTML tags from header
+    temp_df["Text"] = temp_df["Text"].apply(
+        lambda x: BeautifulSoup(x, "html.parser").get_text()
+    )
 
-    proc_text_pattern = re.compile(r"proc text", flags=re.IGNORECASE)
-    temp_df["Text"] = temp_df["Text"].str.replace(proc_text_pattern, "")
+    # 2. Remove "proc text" from header
+    temp_df["Text"] = temp_df["Text"].str.replace("proc text", "", case=False)
 
-    # 2. remove "pages" from header
+    # 3. Remove "pages" from header
+    temp_df["Text"] = temp_df["Text"].str.replace(r"Page  \d+", "")
 
-    page_number_pattern = re.compile(r"Page  \d+")
-    temp_df["Text"] = temp_df["Text"].str.replace(page_number_pattern, "")
-
-    # 3. drop blank rows
+    # 4. Drop blank rows
     temp_df = temp_df[temp_df["Text"].astype(str) != ""]
 
     return temp_df


### PR DESCRIPTION
context:

* in the parsing logic, if successive rows have the same member speaking, the rows are combined.
* example: on [2024-05-07](https://www.parliament.gov.sg/docs/default-source/order-paper/orderpaper-7may2024.pdf), patrick tay asked two questions consecutively. in the parsing logic, the two rows would be combined.
* as a result, the accurate count of primary questions is not possible.

this PR:

* ensures that if the rows are like a question (starts with "asked" or "to ask"), they will not be combined.
* tries to relocate back some missing names - for example, in the format "The question stood in the name of", the name would be missing. tries to get back the name.
* cleans `\t` out of the text.
* cleans out html tags from text content (previously having <span></span> tags in there. only content is kept).
* adds `date` to the raw table of speeches