### PR TITLE
Add cdci artifact registry

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - main  # Change this to your target branch
+      - add-CDCI-artifact-registry  # Change this to your target branch
 
 jobs:
   build:
@@ -19,15 +19,17 @@ jobs:
     - name: Log in to Google Cloud
       uses: google-github-actions/auth@v1
       with:
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
+        credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-    - name: Set up Google Cloud Docker credential helper
-      run: gcloud auth configure-docker --quiet
-
-    - name: Build Docker image
+    - name: Get OAuth2 access token and login to Docker
       run: |
-        docker build -t us-central1-docker.pkg.dev/singapore-parliament-speeches/singapore-parliament-speeches/image:latest .
+        ACCESS_TOKEN=$(gcloud auth print-access-token)
+        echo "$ACCESS_TOKEN" | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
 
-    - name: Push Docker image to Google Artifact Registry
+
+    - name: Build and push Docker image
       run: |
+        docker build --build-arg SECRET_TOKEN=${{ secrets.MY_SECRET_TOKEN }} \
+                     -t us-central1-docker.pkg.dev/singapore-parliament-speeches/singapore-parliament-speeches/image:latest \
+                     .
         docker push us-central1-docker.pkg.dev/singapore-parliament-speeches/singapore-parliament-speeches/image:latest

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - add-CDCI-artifact-registry  # Change this to your target branch
+      - main
 
 jobs:
   build:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -1,0 +1,33 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main  # Change this to your target branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to Google Cloud
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: Set up Google Cloud Docker credential helper
+      run: gcloud auth configure-docker --quiet
+
+    - name: Build Docker image
+      run: |
+        docker build -t us-central1-docker.pkg.dev/singapore-parliament-speeches/singapore-parliament-speeches/image:latest .
+
+    - name: Push Docker image to Google Artifact Registry
+      run: |
+        docker push us-central1-docker.pkg.dev/singapore-parliament-speeches/singapore-parliament-speeches/image:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 ## create directories
 RUN mkdir -p /scripts
 RUN mkdir -p /token
+# get token
 ## copy files
 COPY nltk_req.py .
 RUN python nltk_req.py
-COPY /token /token
+RUN echo "$SECRET_TOKEN" > /token/gcp_token.json
 COPY /scripts/extract /scripts/extract
 COPY /scripts/load /scripts/load
 COPY /scripts/resource-json /scripts/resource-json


### PR DESCRIPTION
This PR:

- allows CDCI by building and pushing to artifact registry on git push
- inherits gcp token from github secrets and passes it to docker during build 